### PR TITLE
DRAFT: Unresolved symlinks for rules_js

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -335,8 +335,9 @@ if [ "${PLATFORM}" = "windows" ]; then
   # We don't rely on runfiles trees on Windows
   cat <<'EOF' >${ARCHIVE_DIR}/build-runfiles${EXE_EXT}
 #!/bin/sh
-mkdir -p $2
-cp $1 $2/MANIFEST
+# Skip over --allow_relative.
+mkdir -p $3
+cp $2 $3/MANIFEST
 EOF
 else
   cat <<'EOF' >${ARCHIVE_DIR}/build-runfiles${EXE_EXT}
@@ -350,8 +351,9 @@ else
 # bootstrap version of Bazel, but we'd still need a shell wrapper around it, so
 # it's not clear whether that would be a win over a few lines of Lovecraftian
 # code)
-MANIFEST="$1"
-TREE="$2"
+# Skip over --allow_relative.
+MANIFEST="$2"
+TREE="$3"
 
 rm -fr "$TREE"
 mkdir -p "$TREE"

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -249,6 +249,7 @@ java_library(
         "starlark/StarlarkRuleContext.java",
         "starlark/StarlarkRuleTransitionProvider.java",
         "starlark/StarlarkTransition.java",
+        "starlark/UnresolvedSymlinkAction.java",
         "test/AnalysisTestActionBuilder.java",
         "test/BaselineCoverageAction.java",
         "test/CoverageCommon.java",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
@@ -36,7 +36,10 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import javax.annotation.Nullable;
 
-/** Action to create a symbolic link. */
+/**
+ * Action to create a symlink to a known-to-exist target with alias semantics similar to a true copy
+ * of the input (if any).
+ */
 public final class SymlinkAction extends AbstractAction {
   private static final String GUID = "7f4fab4d-d0a7-4f0f-8649-1d0337a21fee";
 
@@ -150,13 +153,6 @@ public final class SymlinkAction extends AbstractAction {
     Preconditions.checkState(!execPath.isAbsolute());
     return new SymlinkAction(
         owner, execPath, primaryInput, primaryOutput, progressMessage, TargetType.FILESET);
-  }
-
-  public static SymlinkAction createUnresolved(
-      ActionOwner owner, Artifact primaryOutput, PathFragment targetPath, String progressMessage) {
-    Preconditions.checkArgument(primaryOutput.isSymlink());
-    return new SymlinkAction(
-        owner, targetPath, null, primaryOutput, progressMessage, TargetType.OTHER);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -273,7 +273,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
             ? (String) progressMessageUnchecked
             : "Creating symlink " + outputArtifact.getExecPathString();
 
-    SymlinkAction action;
+    Action action;
     if (targetFile != Starlark.NONE) {
       Artifact inputArtifact = (Artifact) targetFile;
       if (outputArtifact.isSymlink()) {
@@ -324,10 +324,10 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       }
 
       action =
-          SymlinkAction.createUnresolved(
+          new UnresolvedSymlinkAction(
               ruleContext.getActionOwner(),
               outputArtifact,
-              PathFragment.create((String) targetPath),
+              (String) targetPath,
               progressMessage);
     }
     registerAction(action);

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkAction.java
@@ -1,0 +1,112 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.starlark;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.AbstractAction;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionException;
+import com.google.devtools.build.lib.actions.ActionKeyContext;
+import com.google.devtools.build.lib.actions.ActionOwner;
+import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.server.FailureDetails;
+import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.server.FailureDetails.SymlinkAction.Code;
+import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Action to create a possibly unresolved symbolic link to a raw path.
+ *
+ * To create a symlink to a known-to-exist target with alias semantics similar to a true copy of the
+ * input, use {@link SymlinkAction} instead.
+ */
+public final class UnresolvedSymlinkAction extends AbstractAction {
+  private static final String GUID = "0f302651-602c-404b-881c-58913193cfe7";
+
+  private final String target;
+  private final String progressMessage;
+
+  public UnresolvedSymlinkAction(
+      ActionOwner owner,
+      Artifact primaryOutput,
+      String target,
+      String progressMessage) {
+    super(
+        owner,
+        NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+        ImmutableSet.of(primaryOutput));
+    this.target = target;
+    this.progressMessage = progressMessage;
+  }
+
+  @Override
+  public ActionResult execute(ActionExecutionContext actionExecutionContext)
+      throws ActionExecutionException {
+
+    Path outputPath = actionExecutionContext.getInputPath(getPrimaryOutput());
+    try {
+      // TODO: PathFragment#create normalizes the symlink target, which may change how it resolves
+      //  when combined with directory symlinks. Ideally, Bazel's file system abstraction would
+      //  offer a way to create symlinks without any preprocessing of the target.
+      outputPath.createSymbolicLink(PathFragment.create(target));
+    } catch (IOException e) {
+      String message =
+          String.format(
+              "failed to create symbolic link '%s' to '%s' due to I/O error: %s",
+              getPrimaryOutput().getExecPathString(), target, e.getMessage());
+      DetailedExitCode code = createDetailedExitCode(message, Code.LINK_CREATION_IO_EXCEPTION);
+      throw new ActionExecutionException(message, e, this, false, code);
+    }
+
+    return ActionResult.EMPTY;
+  }
+
+  @Override
+  protected void computeKey(
+      ActionKeyContext actionKeyContext,
+      @Nullable ArtifactExpander artifactExpander,
+      Fingerprint fp) {
+    fp.addString(GUID);
+    fp.addString(target);
+  }
+
+  @Override
+  public String getMnemonic() {
+    return "UnresolvedSymlink";
+  }
+
+  @Override
+  protected String getRawProgressMessage() {
+    return progressMessage;
+  }
+
+  private static DetailedExitCode createDetailedExitCode(String message, Code detailedCode) {
+    return DetailedExitCode.of(
+        FailureDetail.newBuilder()
+            .setMessage(message)
+            .setSymlinkAction(FailureDetails.SymlinkAction.newBuilder().setCode(detailedCode))
+            .build());
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -180,8 +180,8 @@ public final class SymlinkTreeHelper {
     Preconditions.checkNotNull(shellEnvironment);
     List<String> args = Lists.newArrayList();
     args.add(binTools.getEmbeddedPath(BUILD_RUNFILES).asFragment().getPathString());
+    args.add("--allow_relative");
     if (filesetTree) {
-      args.add("--allow_relative");
       args.add("--use_metadata");
     }
     args.add(inputManifest.relativeTo(execRoot).getPathString());

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -18,11 +18,13 @@ import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.DirectoryNode;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.FileNode;
+import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.SymlinkNode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.Path;
@@ -142,12 +144,13 @@ class DirectoryTreeBuilder {
                   "missing metadata for '%s'",
                   input.getExecPathString());
           switch (metadata.getType()) {
-            case REGULAR_FILE:
+            case REGULAR_FILE: {
               Digest d = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
               Path inputPath = ActionInputHelper.toInputPath(input, execRoot);
               boolean childAdded =
                   currDir.addChild(FileNode.createExecutable(path.getBaseName(), inputPath, d));
               return childAdded ? 1 : 0;
+            }
 
             case DIRECTORY:
               SortedMap<PathFragment, ActionInput> directoryInputs =
@@ -155,12 +158,16 @@ class DirectoryTreeBuilder {
               return buildFromActionInputs(
                   directoryInputs, metadataProvider, execRoot, digestUtil, tree);
 
-            case SYMLINK:
-              throw new IllegalStateException(
-                  String.format(
-                      "Encountered symlink input '%s', but all"
-                          + " symlinks should have been resolved by SkyFrame. This is a bug.",
-                      path));
+            case SYMLINK: {
+              Preconditions.checkState(input instanceof SpecialArtifact && input.isSymlink(),
+                  "Encountered symlink input '%s', but all source symlinks should have been"
+                      + " resolved by SkyFrame. This is a bug.",
+                  path);
+              Path inputPath = ActionInputHelper.toInputPath(input, execRoot);
+              boolean childAdded = currDir.addChild(new SymlinkNode(path.getBaseName(),
+                  inputPath.readSymbolicLink().getPathString()));
+              return childAdded ? 1 : 0;
+            }
 
             case SPECIAL_FILE:
               throw new IOException(

--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
@@ -48,10 +48,11 @@ public final class SymlinkTreeHelperTest {
     assertThat(command.getEnvironment()).isEmpty();
     assertThat(command.getWorkingDirectory()).isEqualTo(execRoot.getPathFile());
     ImmutableList<String> commandLine = command.getArguments();
-    assertThat(commandLine).hasSize(3);
+    assertThat(commandLine).hasSize(4);
     assertThat(commandLine.get(0)).endsWith(SymlinkTreeHelper.BUILD_RUNFILES);
-    assertThat(commandLine.get(1)).isEqualTo("input_manifest");
-    assertThat(commandLine.get(2)).isEqualTo("output/MANIFEST");
+    assertThat(commandLine.get(1)).isEqualTo("--allow_relative");
+    assertThat(commandLine.get(2)).isEqualTo("input_manifest");
+    assertThat(commandLine.get(3)).isEqualTo("output/MANIFEST");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.DirectoryNode;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.FileNode;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.Node;
+import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.SymlinkNode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -119,7 +120,7 @@ public abstract class DirectoryTreeTest {
   static void assertLexicographicalOrder(DirectoryTree tree) {
     // Assert the lexicographical order as defined by the remote execution protocol
     tree.visit(
-        (PathFragment dirname, List<FileNode> files, List<DirectoryNode> dirs) -> {
+        (PathFragment dirname, List<FileNode> files, List<SymlinkNode> symlinks, List<DirectoryNode> dirs) -> {
           assertThat(files).isInStrictOrder();
           assertThat(dirs).isInStrictOrder();
         });
@@ -136,7 +137,7 @@ public abstract class DirectoryTreeTest {
   private static List<DirectoryNode> directoryNodesAtDepth(DirectoryTree tree, int depth) {
     List<DirectoryNode> directoryNodes = new ArrayList<>();
     tree.visit(
-        (PathFragment dirname, List<FileNode> files, List<DirectoryNode> dirs) -> {
+        (PathFragment dirname, List<FileNode> files, List<SymlinkNode> symlinks, List<DirectoryNode> dirs) -> {
           int currDepth = dirname.segmentCount();
           if (currDepth == depth) {
             directoryNodes.addAll(dirs);
@@ -148,7 +149,7 @@ public abstract class DirectoryTreeTest {
   static List<FileNode> fileNodesAtDepth(DirectoryTree tree, int depth) {
     List<FileNode> fileNodes = new ArrayList<>();
     tree.visit(
-        (PathFragment dirname, List<FileNode> files, List<DirectoryNode> dirs) -> {
+        (PathFragment dirname, List<FileNode> files, List<SymlinkNode> symlinks, List<DirectoryNode> dirs) -> {
           int currDepth = dirname.segmentCount();
           if (currDepth == depth) {
             fileNodes.addAll(files);

--- a/src/test/shell/bazel/bazel_symlink_test.sh
+++ b/src/test/shell/bazel/bazel_symlink_test.sh
@@ -391,11 +391,11 @@ EOF
   cat > a/BUILD <<'EOF'
 load(":a.bzl", "a")
 
-a(name="a", link_target="somewhere/in/my/heart")
+a(name="a", link_target="../somewhere/in/my/heart")
 EOF
 
   bazel build --experimental_allow_unresolved_symlinks //a:a || fail "build failed"
-  assert_contains "input link is .*[/\\]somewhere/in/my/heart" bazel-bin/a/a.file
+  assert_contains "input link is ../somewhere/in/my/heart" bazel-bin/a/a.file
 }
 
 function test_symlink_file_to_file_created_from_symlink_action() {
@@ -709,6 +709,141 @@ genrule(
 EOF
 
   bazel build --experimental_allow_unresolved_symlinks //a:exec || fail "build failed"
+}
+
+function test_unresolved_symlink_hermetic_in_sandbox() {
+  if "$is_windows"; then
+    # TODO(#10298): Support unresolved symlinks on Windows.
+    return 0
+  fi
+
+  mkdir -p pkg
+  cat > pkg/def.bzl <<'EOF'
+def _r(ctx):
+  symlink = ctx.actions.declare_symlink(ctx.label.name + "_s")
+  ctx.actions.symlink(output=symlink, target_path=ctx.file.file.basename)
+
+  output = ctx.actions.declare_file(ctx.label.name)
+  ctx.actions.run_shell(
+    command = "{ cat %s || true; } >  %s" % (symlink.path, output.path),
+    inputs = [symlink] + ([ctx.file.file] if ctx.attr.stage_target else []),
+    outputs = [output],
+  )
+  return DefaultInfo(files=depset([output]))
+
+r = rule(
+    implementation=_r,
+    attrs = {
+        "file": attr.label(allow_single_file=True),
+        "stage_target": attr.bool(),
+    }
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":def.bzl", "r")
+
+genrule(name = "a", outs = ["file"], cmd = "echo hello >$@")
+r(name="b", file="file")
+r(name="c", file="file", stage_target=True)
+EOF
+
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=local
+  [ -s bazel-bin/pkg/b ] && fail "symlink should not resolve"
+
+  bazel clean
+  bazel build //pkg:a --spawn_strategy=sandboxed
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=local
+  [ -s bazel-bin/pkg/b ] || fail "symlink should resolve"
+
+  bazel clean
+  bazel build //pkg:c --experimental_allow_unresolved_symlinks --spawn_strategy=local
+  [ -s bazel-bin/pkg/c ] || fail "symlink should resolve"
+
+  bazel clean
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed
+  [ -s bazel-bin/pkg/b ] && fail "sandboxed build is not hermetic"
+
+  bazel clean
+  bazel build //pkg:a --spawn_strategy=sandboxed
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed
+  [ -s bazel-bin/pkg/b ] && fail "sandboxed build is not hermetic"
+
+  bazel clean
+  bazel build //pkg:c --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed
+  [ -s bazel-bin/pkg/c ] || fail "symlink should resolve"
+}
+
+function test_unresolved_symlink_in_runfiles() {
+  if "$is_windows"; then
+    # TODO(#10298): Support unresolved symlinks on Windows.
+    return 0
+  fi
+
+  mkdir -p pkg
+  cat > pkg/def.bzl <<'EOF'
+def _r(ctx):
+  symlink = ctx.actions.declare_symlink(ctx.label.name + "_s")
+  target = ctx.file.file.basename
+  ctx.actions.symlink(output=symlink, target_path=target)
+
+  script = ctx.actions.declare_file(ctx.label.name)
+  content = """
+#!/usr/bin/env bash
+cd $0.runfiles/{workspace_name}
+[ -L {symlink} ] || {{ echo "runfile is not a symlink"; exit 1; }}
+[ $(readlink {symlink}) == "{target}" ] || {{ echo "runfile symlink does not have the expected target, got: $(readlink {symlink})"; exit 1; }}
+[ -s {symlink} ] || {{ echo "runfile not resolved"; exit 1; }}
+""".format(
+    symlink = symlink.short_path,
+    target = target,
+    workspace_name = ctx.workspace_name,
+  )
+  ctx.actions.write(script, content, is_executable=True)
+
+  runfiles = ctx.runfiles(
+      files = [symlink] + ([ctx.file.file] if ctx.attr.stage_file else []),
+  )
+  return DefaultInfo(executable=script, runfiles=runfiles)
+
+r = rule(
+    implementation = _r,
+    attrs = {
+        "file": attr.label(allow_single_file = True),
+        "stage_file": attr.bool(),
+    },
+    executable = True,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":def.bzl", "r")
+
+genrule(name="a", outs=["file"], cmd="echo hello >$@")
+r(name="tool", file="file", stage_file=True)
+r(name="non_hermetic_tool", file="file", stage_file=False)
+genrule(
+    name = "use_tool",
+    outs = ["out"],
+    cmd = "$(location :tool) && touch $@",
+    tools = [":tool"],
+)
+genrule(
+    name = "use_tool_non_hermetically",
+    outs = ["out_non_hermetic"],
+    cmd = "$(location :non_hermetic_tool) && touch $@",
+    # Stage file outside the runfiles tree.
+    tools = [":non_hermetic_tool", "file"],
+)
+EOF
+
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=local //pkg:use_tool_non_hermetically && fail "symlink in runfiles resolved outside the runfiles tree"
+
+  bazel clean
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=local //pkg:use_tool || fail "local build failed"
+
+  bazel clean
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed //pkg:use_tool || fail "sandboxed build failed"
+  # Keep the implicitly built //pkg:a around to make the symlink resolve outside the sandbox.
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed //pkg:use_tool_non_hermetically && fail "sandboxed symlink in runfiles resolved outside the runfiles tree" || true
 }
 
 run_suite "Tests for symlink artifacts"

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -2883,4 +2883,114 @@ EOF
       || fail "Remote execution generated different result"
 }
 
+function test_external_cc_test() {
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    # TODO(b/37355380): This test is disabled due to RemoteWorker not supporting
+    # setting SDKROOT and DEVELOPER_DIR appropriately, as is required of
+    # action executors in order to select the appropriate Xcode toolchain.
+    return 0
+  fi
+
+  cat >> WORKSPACE <<'EOF'
+local_repository(
+  name = "other_repo",
+  path = "other_repo",
+)
+EOF
+
+  mkdir -p other_repo
+  touch other_repo/WORKSPACE
+
+  mkdir -p other_repo/lib
+  cat > other_repo/lib/BUILD <<'EOF'
+cc_library(
+  name = "lib",
+  srcs = ["lib.cpp"],
+  hdrs = ["lib.h"],
+  visibility = ["//visibility:public"],
+)
+EOF
+  cat > other_repo/lib/lib.h <<'EOF'
+void print_greeting();
+EOF
+  cat > other_repo/lib/lib.cpp <<'EOF'
+#include <cstdio>
+void print_greeting() {
+  printf("Hello, world!\n");
+}
+EOF
+
+  mkdir -p other_repo/test
+  cat > other_repo/test/BUILD <<'EOF'
+cc_test(
+  name = "test",
+  srcs = ["test.cpp"],
+  deps = ["//lib"],
+)
+EOF
+  cat > other_repo/test/test.cpp <<'EOF'
+#include "lib/lib.h"
+int main() {
+  print_greeting();
+}
+EOF
+
+  bazel test \
+      --test_output=errors \
+      --remote_executor=grpc://localhost:${worker_port} \
+      @other_repo//test >& $TEST_log || fail "Test should pass"
+}
+
+function test_unresolved_symlink_input() {
+  mkdir -p symlink
+  touch symlink/BUILD
+  cat > symlink/symlink.bzl <<EOF
+def _dangling_symlink_impl(ctx):
+    symlink = ctx.actions.declare_symlink(ctx.label.name)
+    ctx.actions.symlink(
+        output = symlink,
+        target_path = ctx.attr.link_target,
+    )
+    return DefaultInfo(files = depset([symlink]))
+
+dangling_symlink = rule(
+    implementation = _dangling_symlink_impl,
+    attrs = {"link_target": attr.string()},
+)
+EOF
+
+  mkdir -p pkg
+  cat > pkg/BUILD <<'EOF'
+load("//symlink:symlink.bzl", "dangling_symlink")
+dangling_symlink(name="a", link_target="non/existent")
+genrule(
+    name = "b",
+    srcs = [":a"],
+    outs = ["b.txt"],
+    cmd = "readlink $(location :a) > $@",
+)
+EOF
+
+  bazel \
+    --windows_enable_symlinks \
+    build \
+    --experimental_allow_unresolved_symlinks \
+    --spawn_strategy=remote \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //pkg:b &>$TEST_log || fail "expected build to succeed"
+  [[ $(cat bazel-bin/pkg/b.txt) =~ .*/non/existent ]] || fail "expected symlink target to be non/existent"
+
+  bazel clean --expunge
+  bazel \
+    --windows_enable_symlinks \
+    build \
+    --experimental_allow_unresolved_symlinks \
+    --spawn_strategy=remote \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --experimental_remote_merkle_tree_cache \
+    //pkg:b &>$TEST_log || fail "expected build to succeed with Merkle tree cache"
+  [[ $(cat bazel-bin/pkg/b.txt) =~ .*/non/existent ]] || fail "expected symlink target to be non/existent"
+}
+
+>>>>>>> 26c84be13e (Add RBE support for generated unresolved symlinks)
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
A throw away DRAFT PR to make it easier to see the changes @fmeum has in-flight to get unresolved symlinks over the line so Bazel support symlinks over RBE for rules_js.

This is a combination of:

- Commit from https://github.com/bazelbuild/bazel/compare/master...fmeum:bazel:direct-symlink-staging-no-api branch that stages symlinks directly in runfiles
- Commit from https://github.com/bazelbuild/bazel/pull/15781 that adds symlink support to RBE